### PR TITLE
Changed delegateFunctions to be a clone.

### DIFF
--- a/service/angular-atmosphere-service.js
+++ b/service/angular-atmosphere-service.js
@@ -1,7 +1,7 @@
 angular.module('angular.atmosphere', [])
   .service('atmosphereService', function($rootScope){
     var responseParameterDelegateFunctions = ['onOpen', 'onClientTimeout', 'onReopen', 'onMessage', 'onClose', 'onError'];
-    var delegateFunctions = responseParameterDelegateFunctions;
+    var delegateFunctions = JSON.parse(JSON.stringify(responseParameterDelegateFunctions));
     delegateFunctions.push('onTransportFailure');
     delegateFunctions.push('onReconnect');
 


### PR DESCRIPTION
delegateFunctions was referencing the same space in memory as responseParameterDelegateFunctions, so onTransportFailure and onReconnect where both being pushed into responseParameterDelegateFunctions.  The effect was that the 'else if' statements for onTransportFailure and onReconnect where unreachable.  Refactored to make delagateFunctions a proper clone.  